### PR TITLE
Fixes to HTML Convert doc

### DIFF
--- a/html_convert.md
+++ b/html_convert.md
@@ -34,8 +34,7 @@ You can specify the response content type to return the converted HTML in either
 Replace `{apikey_value}` with the API key you copied earlier and `{PDF_file}` with the path to the PDF to convert.
 
 ```bash
-curl -X POST -u "apikey":"{apikey_value}" -H "Content-Type: application/json"
--F "file=@{PDF_file};type=application/pdf" https://gateway.watsonplatform.net/compare-comply/api/v1/tables?version=2018-10-15
+curl -X POST -u "apikey":"{apikey_value}" -H "Content-Type: application/json" -F "file=@{PDF_file};type=application/pdf" https://gateway.watsonplatform.net/compare-comply/api/v1/html_conversion?version=2018-10-15
 ```
 {: pre}
 

--- a/html_convert.md
+++ b/html_convert.md
@@ -28,13 +28,13 @@ In a `bash` shell or equivalent environment such as Cygwin, use the `POST /v1/ht
   - `model` (optional `string`): If this parameter is specified, the service runs the specified type of element classification. Currently, the only supported value is `contracts`.
   
 You can specify the response content type to return the converted HTML in either JSON (the default) or raw HTML. See the examples following the command example for the different formats.
-  - To return JSON explicitly, specify the header `-H 'Content-Type: application/json'`. This is the default.
+  - To return JSON explicitly, specify the header `-H 'Accept: application/json'`. This is the default.
   - To return raw HTML, specify the header `-H 'Accept: text/html'`.
   
 Replace `{apikey_value}` with the API key you copied earlier and `{PDF_file}` with the path to the PDF to convert.
 
 ```bash
-curl -X POST -u "apikey":"{apikey_value}" -H "Content-Type: application/json" -F "file=@{PDF_file};type=application/pdf" https://gateway.watsonplatform.net/compare-comply/api/v1/html_conversion?version=2018-10-15
+curl -X POST -u "apikey":"{apikey_value}" -H "Accept: application/json" -F "file=@{PDF_file};type=application/pdf" https://gateway.watsonplatform.net/compare-comply/api/v1/html_conversion?version=2018-10-15
 ```
 {: pre}
 


### PR DESCRIPTION
Stumbled across a couple typos when trying to follow to docs today.

- changed endpoint in code sample from /v1/tables to /v1/html_conversion
- put code sample onto one line so that it can be copied into terminal
- changed header from 'Content-Type: application/json' to 'Accept: application/json'. Using Content-Type returns the following error 

```
{
  "code" : 500,
  "error" : "Failed to parse multipart servlet request; nested exception is org.apache.commons.fileupload.FileUploadBase$InvalidContentTypeException: the request doesn't contain a multipart/form-data or multipart/mixed stream, content type header is application/json; boundary=------------------------7f82b7cf2c975423"
}
```